### PR TITLE
Allow volume and market cap fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -267,7 +267,7 @@ function snapshot(options, cb) {
   }
 
   // Avoid CSV column result mis-alignment (000,000,000).
-  options.fields = _.without(options.fields, 't6', 'j1', 'j3', 'f6', 'j2', 'v', 'a5', 'b6', 'k3');
+  options.fields = _.without(options.fields, 't6', 'f6', 'j2', 'a5', 'b6', 'k3');
 
   var url = 'http://download.finance.yahoo.com/d/quotes.csv?' + querystring.stringify({
     s: options.symbols.join(','),


### PR DESCRIPTION
"The CSV column mis-alignment doesn't seem to occur with the
volume, market capitalization, and market cap (realtime) fields.
Allow these fields to be queried."

I've tested these changes with multiple stocks, and don't come across any problems (as I would with other fields that do have this problem).  I find these fields to be important, and really like the simplicity of your module.  Would it be possible to accept this pull request and enable these fields to be queried?

Thanks!
