### PR TITLE
Fixed date conversion problem by using moment.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,8 @@ var S = require('string');
 var debug = require('debug')('yahoo-finance:utils');
 var Promise = require('bluebird');
 var request = require('request');
+var moment = require('moment');
+var dateFormat = "YYYY-MM-DD";
 
 request = Promise.promisifyAll(request);
 
@@ -38,7 +40,7 @@ function parseCSV(text) {
 
 function toDate(value, valueForError) {
   try {
-    var date = new Date(value);
+    var date = moment(value, dateFormat).toDate();
     if (date.getFullYear() < 1400) { return null; }
     return date;
   } catch (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ var debug = require('debug')('yahoo-finance:utils');
 var Promise = require('bluebird');
 var request = require('request');
 var moment = require('moment');
-var dateFormat = "YYYY-MM-DD";
+var dateFormat = 'YYYY-MM-DD';
 
 request = Promise.promisifyAll(request);
 


### PR DESCRIPTION
I'm using this for a pet project and I noticed that the lib was not creating dates correctly from the string in the historical data CSV. The `Date` object being created was actually a day earlier than the specified string. Not sure exactly why this was happening, but, since `moment` was already available, I fixed it by creating the `moment` object with an explicit format and then grabbing the raw JS date object. Seems to work.

Thanks for the library!