### PR TITLE
Fix toDate to handle multiple formats

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ var debug = require('debug')('yahoo-finance:utils');
 var Promise = require('bluebird');
 var request = require('request');
 var moment = require('moment');
-var dateFormat = 'YYYY-MM-DD';
+var dateFormats = ['YYYY-MM-DD', 'MM/DD/YYYY'];
 
 request = Promise.promisifyAll(request);
 
@@ -40,7 +40,7 @@ function parseCSV(text) {
 
 function toDate(value, valueForError) {
   try {
-    var date = moment(value, dateFormat).toDate();
+    var date = moment(value, dateFormats).toDate();
     if (date.getFullYear() < 1400) { return null; }
     return date;
   } catch (err) {


### PR DESCRIPTION
#12 broke the conversion of the d1 field for snapshots. This fixes it by using moment's ability to specify multiple alternative formats.