### PR TITLE
Promise based changes in historical and snapshot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,50 +206,45 @@ function _transformSnapshot(fields, symbols, data) {
 }
 
 function historical(options, cb) {
-  var symbols;
-  return Promise.resolve()
-    .then(function () {
-      options = _.clone(options);
-      _sanitizeHistoricalOptions(options);
+  options = _.clone(options);
+  _sanitizeHistoricalOptions(options);
+  var symbols = options.symbols || _.flatten([options.symbol]);
+  
+  return Promise.map(symbols, function (symbol) {
+    return _utils.download(_constants.HISTORICAL_URL, {
+      s: symbol,
+      a: options.from.format('MM') - 1,
+      b: options.from.format('DD'),
+      c: options.from.format('YYYY'),
+      d: options.to.format('MM') - 1,
+      e: options.to.format('DD'),
+      f: options.to.format('YYYY'),
+      g: options.period,
+      ignore: '.csv'
     })
-    .then(function () {
-      return symbols = options.symbols || _.flatten([options.symbol]);
-    })
-    .map(function (symbol) {
-      return _utils.download(_constants.HISTORICAL_URL, {
-        s: symbol,
-        a: options.from.format('MM') - 1,
-        b: options.from.format('DD'),
-        c: options.from.format('YYYY'),
-        d: options.to.format('MM') - 1,
-        e: options.to.format('DD'),
-        f: options.to.format('YYYY'),
-        g: options.period,
-        ignore: '.csv'
-      })
-      .then(_utils.parseCSV)
-      .then(function (data) {
-        return _transformHistorical(symbol, data);
-      })
-      .catch(function (err) {
-        if (options.error) {
-          throw err;
-        } else {
-          return [];
-        }
-      });
-    }, {concurrency: os.cpus().length})
-    .then(function (result) {
-      if (options.symbols) {
-        return _.zipObject(symbols, result);
-      } else {
-        return result[0];
-      }
+    .then(_utils.parseCSV)
+    .then(function (data) {
+      return _transformHistorical(symbol, data);
     })
     .catch(function (err) {
-      throw new Error(util.format('Failed to download data (%s)', err.message));
-    })
-    .nodeify(cb);
+      if (options.error) {
+        throw err;
+      } else {
+        return [];
+      }
+    });
+  })
+  .then(function (result) {
+    if (options.symbols) {
+      return _.zipObject(symbols, result);
+    } else {
+      return result[0];
+    }
+  })
+  .catch(function (err) {
+    throw new Error(util.format('Failed to download data (%s)', err.message));
+  })
+  .nodeify(cb);
 }
 
 function snapshot(options, cb) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -233,7 +233,7 @@ function historical(options, cb) {
         return [];
       }
     });
-  })
+  }, {concurrency: options.maxConcurrentSymbols || os.cpus().length})
   .then(function (result) {
     if (options.symbols) {
       return _.zipObject(symbols, result);

--- a/lib/index.js
+++ b/lib/index.js
@@ -248,20 +248,13 @@ function historical(options, cb) {
 }
 
 function snapshot(options, cb) {
-  var symbols;
-  return Promise.resolve()
-    .then(function () {
-      options = _.clone(options);
-      _sanitizeSnapshotOptions(options);
-    })
-    .then(function () {
-      symbols = options.symbols || _.flatten([options.symbol]);
-    })
-    .then(function () {
-      return _utils.download(_constants.SNAPSHOT_URL, {
-        s: symbols.join(','),
-        f: options.fields.join('')
-      });
+  var symbols = options.symbols || _.flatten([options.symbol]);
+  options = _.clone(options);
+  _sanitizeSnapshotOptions(options);
+  
+  return _utils.download(_constants.SNAPSHOT_URL, {
+      s: symbols.join(','),
+      f: options.fields.join('')
     })
     .then(_utils.parseCSV)
     .then(function (data) {


### PR DESCRIPTION
Removed unnecessary `Promise.resolve()`

Added `options.maxConcurrentSymbols` to specify the number of requests as the same time. If not set, use ` os.cpus().length` but it would be better to increase that number. The CPU can handle much more Promises than its cores. The bottleneck is on the HTTP requests time where could be very lazy dealing with hundred of symbols.