### PR TITLE
parse date as America/New_York

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var S = require('string');
 var debug = require('debug')('yahoo-finance:utils');
 var request = require('request-promise');
-var moment = require('moment');
+var moment = require('moment-timezone');
 var dateFormats = ['YYYY-MM-DD', 'MM/DD/YYYY'];
 
 function camelize(text) {
@@ -28,7 +28,7 @@ function parseCSV(text) {
 
 function toDate(value, valueForError) {
   try {
-    var date = moment(value, dateFormats).toDate();
+    var date = moment.tz(value, dateFormats, 'America/New_York').toDate();
     if (date.getFullYear() < 1400) { return null; }
     return date;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "debug": "2.2.0",
     "lodash": "4.15.0",
     "moment": "2.14.1",
+    "moment-timezone": "^0.5.10",
     "request": "2.74.0",
     "request-promise": "4.1.1",
     "string": "3.3.1"


### PR DESCRIPTION
dates from yahoo-finance api should be considered eastern time (nasdaq stock exchange).

if parsing as local time, people in other timezones may end up with invalid timestamps