### PR TITLE
Fix non-browser block by claiming to be a Mozilla browser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,8 @@ function download(uri, qs, optionalHttpRequestOptions) {
   var finalHttpRequestOptions = augmentHttpRequestOptions(optionalHttpRequestOptions);
 
   debug(url.format({pathname: uri, query: qs}));
-  return request(_.extend({uri: uri, qs: qs}, finalHttpRequestOptions))
+  var headers = {"user-agent": "Mozilla/5.0"};
+  return request(_.extend({uri: uri, qs: qs, headers: headers}, finalHttpRequestOptions))
     .then(function(res) {
       storeCookiesInJar(res.headers['set-cookie'], uri, cookiejar);
       return (optionalHttpRequestOptions &&


### PR DESCRIPTION
This fixes https://github.com/pilwon/node-yahoo-finance/issues/67

Requests towards yahoofinance.yom claim to be sent from the `User-Agent: Mozilla`.