### PR TITLE
Fix historical array call erroring for empty string

### DIFF
--- a/lib/historical.js
+++ b/lib/historical.js
@@ -24,7 +24,7 @@ function _sanitizeHistoricalOptions(options) {
     throw new Error('"options.error" must be a boolean value');
   }
   if (!_.isUndefined(options.symbol)) {
-    if (!_.isString(options.symbol) || _.isEmpty(options.symbol)) {
+    if (!_.isString(options.symbol) && _.isEmpty(options.symbol)) {
       throw new Error('"options.symbol" must be a non-empty string.');
     }
   } else {


### PR DESCRIPTION
When passing an array to the `historical` call like below,

```
yahooFinance.historical(
        {
          symbol: ['GOOG', 'AAPL'],
          from: '2012-01-01',
          to: '2012-12-31'
        },
        function(err, quotes) {}
      )```

you trigger the following error `options.symbol" must be a non-empty string.`

on line 27:
`if (!_.isString(options.symbol) || _.isEmpty(options.symbol)) {`
the first half returns false since we have an array but the second half returns true.
I changed this to:
`if (!_.isString(options.symbol) && _.isEmpty(options.symbol)) {`
so options.symbol had to both a string and empty to trigger the if. It now successfully falls through to the else part of the function where the array can be checked.
