### PR TITLE
Enable smaller "period" increments

### DIFF
--- a/lib/historical.js
+++ b/lib/historical.js
@@ -62,8 +62,8 @@ function _sanitizeHistoricalOptions(options) {
   }
 
   if (_.isString(options.period)) {
-    if (!_.includes(['d', 'w', 'm', 'v'], options.period)) {
-      throw new Error('"options.period" must be "d", "w", "m", or "v".');
+    if (!_.includes(['1m', '2m', '5m', '15m', '30m', '60m', '90m', 'd', 'w', 'm', 'v'], options.period)) {
+      throw new Error('"options.period" must be "1m", "2m", "5m", "15m", "30m", "60m", "90m", "d", "w", "m", or "v".');
     }
   } else {
     if (!_.isUndefined(options.period) && !_.isNull(options.period)) {


### PR DESCRIPTION
Yahoo's API supports minute-level timescales for historical quotes.