### PR TITLE
readme: note about v2 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,23 @@ The library handles fetching, parsing, and cleaning of CSV data and returns JSON
 
 Also check out [google-finance](https://github.com/pilwon/node-google-finance).
 
+## NB: v1 is feature frozen, v2 in beta
 
-## Important: New Yahoo API
+Please note that v1 is feature frozen.  It has been stable for years, and we
+are no longer working on it (besides for any urgent security fixes).  We have
+a v2 candidate in beta at https://github.com/gadicc/node-yahoo-finance2.
+
+* If you're just starting off, or are feeling adventurous, check out the v2 beta, which has a new API.
+
+* If you're an existing user, keep with the current stable version, and
+  await official upgrade instructions.  We anticipate a v2 stable release
+  around July 2021.
+
+Please submit feature requests only to https://github.com/gadicc/node-yahoo-finance2.
+
+*The rest of this README refers to v1 only.*
+
+## Yahoo's 2017 API Change
 
 This project is compatible with Yahoo's "new" (and internal) API from
 2017-05-16.  Please be aware that Yahoo stopped supporting their API for


### PR DESCRIPTION
@pilwon assuming you're cool with this, will merge if i don't hear back.

also, I added you to the copyright on my v2 repo.

The beta is fairly stable already but I'm aiming for a proper stable release around July.  By then I'll have an upgrade path / guide available.

If I recall correctly, we agreed to publish v2 as part of the existing npm package.  At that point I'll publish a new node-yahoo-finance2 package with a deprecation notice and to use the official package.

The repo is a little more problematic as I have alooot of automation in place with various services, but we can cross that road closer to the time.  Could make sense to archive this repo and focus on the new API on mine, otherwise at the least we should try tag or close all old issues.  Anyway, we have a few months to decide.