### PR TITLE
adding optional events (split, capital and div)

### DIFF
--- a/lib/historical.js
+++ b/lib/historical.js
@@ -71,6 +71,16 @@ function _sanitizeHistoricalOptions(options) {
     }
   }
 
+  if (_.isString(options.events)) {
+    if (!_.includes(['split', 'div', 'capital', 'history'], options.events)) {
+      throw new Error('"options.events" must be "split", "div", "capital", or "history".');
+    }
+  } else {
+    if (!_.isUndefined(options.events) && !_.isNull(options.events)) {
+      throw new Error('"options.events" must be a string or undefined/null.');
+    }
+  }
+
   if (!options.from) {
     options.from = moment('1900-01-01');
   }
@@ -83,7 +93,9 @@ function _sanitizeHistoricalOptions(options) {
     options.period = '1d';
   }
 
-  options.events = 'history';
+  if (!options.events) {
+    options.events = 'history';
+  }
 
   // Convert to yahoo v7 API
   switch (options.period) {


### PR DESCRIPTION
Today at work i had to fetch some data from yahoo, i used this lib to do this. But when i was trying to fetch the stock splits, i was not able to select the type. So this pull request was made to resolve this problem.

This pull request its just to the people be able to select the type of events they wanna fetch, can be "split", "div", "capital" and by default "history"